### PR TITLE
hotfix: 경로서버 관광지 정보조회 로직 수정

### DIFF
--- a/src/main/java/com/earseo/sight/service/internal/InternalSightService.java
+++ b/src/main/java/com/earseo/sight/service/internal/InternalSightService.java
@@ -7,7 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +22,14 @@ public class InternalSightService {
     public List<SightMetaResponse> getSightByIds(List<String> ids) {
         List<SightMetaDto> dtos = sightRepository.findByContentId(ids);
 
+        Map<String, Integer> orderMap = new HashMap<>();
+        for (int i = 0; i < ids.size(); i++) {
+            orderMap.put(ids.get(i), i);
+        }
+
         return dtos.stream()
-                .map(
-                        SightMetaResponse::toDto
-                )
+                .sorted(Comparator.comparingInt(dto -> orderMap.get(dto.contentId())))
+                .map(SightMetaResponse::toDto)
                 .toList();
     }
 }


### PR DESCRIPTION
## 🧩 구현/변경 사항
- 경로서버에서 feign으로 관광지 정보를 조회하던 api에서 아이템 순서대로 조회하지 않던 버그를 수정

